### PR TITLE
Feature/symbol table progmem

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ This library is maintained by LU1AAT Andres (lu1aat.andres at gmail dot com)
 - Hellduino: Sending Hellschreiber from an Arduino: https://brainwagon.org/2012/01/11/hellduino-sending-hellschreiber-from-an-arduino/
 - Sending hellschreiber from an Arduino –> Helldunio!: http://www.lb3hc.net/archives/1303
 - ARDUINO FOR HAM RADIO | Hellschreiber: https://k183.bake-neko.net/ji3bnb/page14.html
+
+
+## Changelog
+
+#### 0.1.0 - 27/07/2022
+
+- Initial release
+- Support for only uppercase letters, numbers and six simbols.

--- a/src/Hell.cpp
+++ b/src/Hell.cpp
@@ -15,7 +15,7 @@ Hell::Hell(int pin) {
 //
 // This python line helps to build each column `hex(int("0010000", 2))`
 //
-int hellSymbols[][7] = {
+const unsigned int hellSymbols[][7] PROGMEM = {
     {0x3E, 0x28, 0x28, 0x28, 0x3E},       // 0  A
     {0x7C, 0x54, 0x54, 0x54, 0x28},       // 1  B
     {0x3E, 0x22, 0x22, 0x22, 0x00},       // 2  C
@@ -102,7 +102,7 @@ void Hell::tx(char message[]) {
     // Get symbols for this character, send signals by setting _pin into HIGH in the required intervals
     for(byte ii = 0; ii < _columns; ii++) {
       int column = 0;
-      column = hellSymbols[symbolIndex][ii];
+      column = pgm_read_word_near(hellSymbols[symbolIndex] + ii);
 
       // Iter over pixels
       int pix;

--- a/src/Hell.h
+++ b/src/Hell.h
@@ -8,13 +8,13 @@ class Hell
         void tone();
         void tx(char message[]);
     private:
-        int _pin;
+        unsigned int _pin;
     
-        const int _toneDurationMicrosconds = 8160;  // Tone ("pixel") duration
-        const int _wordSpacingMs = ((_toneDurationMicrosconds / 1000) * 7) * 7;             // Delay spacing between words
-        const int _columns = 7;                     // How many "columns" (pixels wide) have a single character
-        int _hellSymbols;                           // Symbol table, declared in Hell.cpp
-        int _charDelay = (_toneDurationMicrosconds / 1000) * 7;   // Delay between each character of the message in millisencos
+        const unsigned int _toneDurationMicrosconds = 8160;  // Tone ("pixel") duration
+        const unsigned int _wordSpacingMs = ((_toneDurationMicrosconds / 1000) * 7) * 7;             // Delay spacing between words
+        const unsigned int _columns = 7;                     // How many "columns" (pixels wide) have a single character
+        const unsigned int _hellSymbols;                           // Symbol table, declared in Hell.cpp
+        const unsigned int _charDelay = (_toneDurationMicrosconds / 1000) * 7;   // Delay between each character of the message in millisencos
 
         int _charCurrent;
 };


### PR DESCRIPTION
Use `PROGMEM` to store the symbol table, this make the library to work on ATTiny85 micro-controller.